### PR TITLE
chore: update README.md usage with themes names

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,15 @@
 
 ## Usage
 
+### Built-in
 Catppuccin is [included in Zellij](https://zellij.dev/documentation/theme-gallery.html#catppuccin-latte)! To set Zellij to your preferred flavor,
 see "[Getting Zellij to pick up the theme - Zellij](https://zellij.dev/documentation/themes#getting-zellij-to-pick-up-the-theme)."
+
+#### Themes Name
+- `catppuccin-latte`
+- `catppuccin-frappe`
+- `catppuccin-macchiato`
+- `catppuccin-mocha`
 
 ### Manual
 


### PR DESCRIPTION
I personally think it is nicer to have the name of the themes be in the read me instead of going inside the config file, seeing how it is called.